### PR TITLE
renovate: Disable renovate updates for meta-ked-bsp & meta-ked-bootloader submodules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,11 @@
 {
 	"extends": [
 		"github>balena-os/renovate-config"
+	],
+	"packageRules": [
+		{
+			"matchPackageNames": ["layers/meta-ked-bsp", "layers/meta-ked-bootloader"],
+			"enabled": false
+		}
 	]
 }


### PR DESCRIPTION
Changelog-entry: Disable renovate updates for meta-ked-bsp & meta-ked-bootloader submodules
